### PR TITLE
Reformat line in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ Another option is to place the jar file in the Circus Train `lib` folder which w
 ## Configuration
 * Add the following to the Circus Train YAML configuration in order to load the BigQuery extension via Circus Train's [extension loading mechanism](https://github.com/HotelsDotCom/circus-train#loading-extensions):
 
+```
      extension-packages: com.hotels.bdp.circustrain.bigquery
+```
      
 * Configure Circus Train as you would for a copy job from Google Cloud [Configuration](https://github.com/HotelsDotCom/circus-train/tree/master/circus-train-gcp)
 * Provide the Google Cloud project ID that your BigQuery instance resides in as your `source-catalog` `hive-metastore-uris` parameter using the format `hive-metastore-uris: bigquery://<project-id>`


### PR DESCRIPTION
Change from:
![image](https://user-images.githubusercontent.com/11900207/48709658-1fa61a00-ebfe-11e8-9b0e-30616364f38f.png)
to 
![image](https://user-images.githubusercontent.com/11900207/48709697-38aecb00-ebfe-11e8-9c5a-667207a1c4d4.png)

For some reason, the line should be highlighted as code, based on how `export CIRCUS_TRAIN_CLASSPATH=$CIRCUS_TRAIN_CLASSPATH:/opt/circus-train-big-query/lib/*` is written. But if GitHub doesn't want to show it properly, we'll force it.