### PR TITLE
Add replication profile for components

### DIFF
--- a/src/main/java/com/hotels/bdp/circustrain/bigquery/client/BigQueryMetastoreClientFactory.java
+++ b/src/main/java/com/hotels/bdp/circustrain/bigquery/client/BigQueryMetastoreClientFactory.java
@@ -17,8 +17,10 @@ package com.hotels.bdp.circustrain.bigquery.client;
 
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
+import com.hotels.bdp.circustrain.api.Modules;
 import com.hotels.bdp.circustrain.bigquery.CircusTrainBigQueryConstants;
 import com.hotels.bdp.circustrain.bigquery.extraction.service.ExtractionService;
 import com.hotels.bdp.circustrain.bigquery.table.service.TableServiceFactory;
@@ -28,6 +30,7 @@ import com.hotels.hcommon.hive.metastore.client.api.CloseableMetaStoreClient;
 import com.hotels.hcommon.hive.metastore.client.api.ConditionalMetaStoreClientFactory;
 import com.hotels.hcommon.hive.metastore.exception.MetaStoreClientException;
 
+@Profile({ Modules.REPLICATION })
 @Component
 public class BigQueryMetastoreClientFactory implements ConditionalMetaStoreClientFactory {
 

--- a/src/main/java/com/hotels/bdp/circustrain/bigquery/conf/PartitioningConfiguration.java
+++ b/src/main/java/com/hotels/bdp/circustrain/bigquery/conf/PartitioningConfiguration.java
@@ -28,14 +28,17 @@ import org.apache.hadoop.hive.metastore.api.Table;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 import com.hotels.bdp.circustrain.api.CircusTrainException;
+import com.hotels.bdp.circustrain.api.Modules;
 import com.hotels.bdp.circustrain.api.conf.SourceTable;
 import com.hotels.bdp.circustrain.api.conf.TableReplication;
 import com.hotels.bdp.circustrain.api.conf.TableReplications;
 import com.hotels.bdp.circustrain.bigquery.util.TableNameFactory;
 
+@Profile({ Modules.REPLICATION })
 @Component
 public class PartitioningConfiguration {
 
@@ -48,8 +51,9 @@ public class PartitioningConfiguration {
     Map<String, Map<String, Object>> replicationConfigMap = new HashMap<>();
     for (TableReplication tableReplication : tableReplications.getTableReplications()) {
       SourceTable sourceTable = tableReplication.getSourceTable();
-      String key = TableNameFactory.newInstance(sourceTable.getDatabaseName().trim().toLowerCase(),
-          sourceTable.getTableName().trim().toLowerCase());
+      String key = TableNameFactory
+          .newInstance(sourceTable.getDatabaseName().trim().toLowerCase(),
+              sourceTable.getTableName().trim().toLowerCase());
       if (replicationConfigMap.containsKey(key)) {
         throw new CircusTrainException(
             "Partitioning cannot be carried out when there are duplicate source tables with partitioning configured");

--- a/src/main/java/com/hotels/bdp/circustrain/bigquery/extraction/service/ExtractionService.java
+++ b/src/main/java/com/hotels/bdp/circustrain/bigquery/extraction/service/ExtractionService.java
@@ -20,15 +20,18 @@ import java.util.List;
 import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 import com.google.cloud.bigquery.Table;
 import com.google.cloud.storage.Storage;
 import com.google.common.annotations.VisibleForTesting;
 
+import com.hotels.bdp.circustrain.api.Modules;
 import com.hotels.bdp.circustrain.bigquery.extraction.container.ExtractionContainer;
 import com.hotels.bdp.circustrain.bigquery.extraction.container.PostExtractionAction;
 
+@Profile({ Modules.REPLICATION })
 @Component
 public class ExtractionService {
 

--- a/src/main/java/com/hotels/bdp/circustrain/bigquery/partition/PartitionQueryFactory.java
+++ b/src/main/java/com/hotels/bdp/circustrain/bigquery/partition/PartitionQueryFactory.java
@@ -21,8 +21,12 @@ import static org.apache.commons.lang.StringUtils.isNotBlank;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
+import com.hotels.bdp.circustrain.api.Modules;
+
+@Profile({ Modules.REPLICATION })
 @Component
 public class PartitionQueryFactory {
 

--- a/src/main/java/com/hotels/bdp/circustrain/bigquery/table/service/TableServiceFactory.java
+++ b/src/main/java/com/hotels/bdp/circustrain/bigquery/table/service/TableServiceFactory.java
@@ -22,10 +22,12 @@ import java.util.Map;
 
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 import com.google.common.annotations.VisibleForTesting;
 
+import com.hotels.bdp.circustrain.api.Modules;
 import com.hotels.bdp.circustrain.bigquery.api.TableService;
 import com.hotels.bdp.circustrain.bigquery.conf.PartitioningConfiguration;
 import com.hotels.bdp.circustrain.bigquery.extraction.service.ExtractionService;
@@ -38,6 +40,7 @@ import com.hotels.bdp.circustrain.bigquery.table.service.unpartitioned.Unpartiti
 import com.hotels.bdp.circustrain.bigquery.util.BigQueryMetastore;
 import com.hotels.bdp.circustrain.bigquery.util.SchemaExtractor;
 
+@Profile({ Modules.REPLICATION })
 @Component
 public class TableServiceFactory {
 

--- a/src/main/java/com/hotels/bdp/circustrain/bigquery/util/BigQueryMetastore.java
+++ b/src/main/java/com/hotels/bdp/circustrain/bigquery/util/BigQueryMetastore.java
@@ -21,6 +21,7 @@ import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
 import org.apache.hadoop.hive.metastore.api.UnknownDBException;
 import org.apache.thrift.TException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 import com.google.cloud.bigquery.BigQuery;
@@ -33,7 +34,9 @@ import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.TableResult;
 
 import com.hotels.bdp.circustrain.api.CircusTrainException;
+import com.hotels.bdp.circustrain.api.Modules;
 
+@Profile({ Modules.REPLICATION })
 @Component
 public class BigQueryMetastore {
 
@@ -89,7 +92,11 @@ public class BigQueryMetastore {
   }
 
   private QueryJobConfiguration configureFilterJob(String databaseName, String tableName, String partitionFilter) {
-    return QueryJobConfiguration.newBuilder(partitionFilter).setDestinationTable(TableId.of(databaseName, tableName))
-        .setUseLegacySql(false).setAllowLargeResults(true).build();
+    return QueryJobConfiguration
+        .newBuilder(partitionFilter)
+        .setDestinationTable(TableId.of(databaseName, tableName))
+        .setUseLegacySql(false)
+        .setAllowLargeResults(true)
+        .build();
   }
 }

--- a/src/main/java/com/hotels/bdp/circustrain/bigquery/util/SchemaExtractor.java
+++ b/src/main/java/com/hotels/bdp/circustrain/bigquery/util/SchemaExtractor.java
@@ -25,6 +25,7 @@ import org.apache.avro.file.DataFileStream;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.DatumReader;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 import com.google.api.gax.paging.Page;
@@ -33,8 +34,10 @@ import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.Storage.BlobListOption;
 
 import com.hotels.bdp.circustrain.api.CircusTrainException;
+import com.hotels.bdp.circustrain.api.Modules;
 import com.hotels.bdp.circustrain.bigquery.extraction.container.ExtractionUri;
 
+@Profile({ Modules.REPLICATION })
 @Component
 public class SchemaExtractor {
 
@@ -47,8 +50,7 @@ public class SchemaExtractor {
   }
 
   private String extractSchemaFromFile(Blob blob) {
-    try (ReadableByteChannel reader = blob.reader();
-      InputStream input = Channels.newInputStream(reader)) {
+    try (ReadableByteChannel reader = blob.reader(); InputStream input = Channels.newInputStream(reader)) {
       Schema schema = extractAvroSchema(input);
       return schema.toString();
     } catch (IOException e) {

--- a/src/test/java/com/hotels/bdp/circustrain/bigquery/util/SchemaUtils.java
+++ b/src/test/java/com/hotels/bdp/circustrain/bigquery/util/SchemaUtils.java
@@ -60,10 +60,8 @@ public class SchemaUtils {
     return new StubReadChannel(file.getChannel());
   }
 
-  public static void setUpSchemaMocks(Storage storage, Blob blob, Page<Blob> blobs)
-      throws IOException {
-    when(storage.list(anyString(), any(BlobListOption.class), any(BlobListOption.class)))
-    .thenReturn(blobs);
+  public static void setUpSchemaMocks(Storage storage, Blob blob, Page<Blob> blobs) throws IOException {
+    when(storage.list(anyString(), any(BlobListOption.class), any(BlobListOption.class))).thenReturn(blobs);
     when(blobs.iterateAll()).thenReturn(Arrays.asList(blob));
     when(blob.reader()).thenReturn(getTestData());
   }


### PR DESCRIPTION
The replication profile is addd so components don't load when the housekeeping module is used.

Fixes #28 .

This was tested, and it works as expected.