### PR TITLE
Upgrades to Circus Train and parent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# [TBD]
+# [5.1.0] - 2019-05-09
 ### Changed
 * Refactored project to remove checkstyle and findbugs warnings, which does not impact functionality.
 * Upgraded `circus-train-version` to 14.0.1 (was 13.0.0).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # [TBD]
 ### Changed
 * Refactored project to remove checkstyle and findbugs warnings, which does not impact functionality.
-* Upgraded `hotels-oss-parent` to 2.3.5 (was 2.3.3).
+* Upgraded `circus-train-version` to 14.0.1 (was 13.0.0).
+* Upgraded `hotels-oss-parent` to 4.0.1 (was 2.3.3).
 * Upgraded `google-cloud-bom` to 0.73.0-alpha (was 0.34.0-alpha).
 * Shade and relocate all `com.google` packages (to fix Guava version issue).
 

--- a/README.md
+++ b/README.md
@@ -107,4 +107,4 @@ If you would like to ask any questions about or discuss Circus Train BigQuery pl
 # Legal
 This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
 
-Copyright 2018 Expedia Inc.
+Copyright 2018-2019 Expedia, Inc.

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>hotels-oss-parent</artifactId>
-    <version>2.3.5</version>
+    <version>4.0.1</version>
   </parent>
 
   <artifactId>circus-train-bigquery</artifactId>
@@ -20,7 +20,8 @@
   </scm>
 
   <properties>
-    <circus-train-version>13.0.0</circus-train-version>
+    <jdk.version>1.7</jdk.version>
+    <circus-train-version>14.0.1</circus-train-version>
     <google-cloud.version>0.73.0-alpha</google-cloud.version>
     <hadoop.version>2.7.1</hadoop.version>
     <hive.version>2.3.3</hive.version>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   </parent>
 
   <artifactId>circus-train-bigquery</artifactId>
-  <version>5.0.5-SNAPSHOT</version>
+  <version>5.1.0-SNAPSHOT</version>
   <name>Bigquery Client</name>
   <inceptionYear>2018</inceptionYear>
 

--- a/src/main/java/com/hotels/bdp/circustrain/bigquery/CircusTrainBigQueryConstants.java
+++ b/src/main/java/com/hotels/bdp/circustrain/bigquery/CircusTrainBigQueryConstants.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/hotels/bdp/circustrain/bigquery/RuntimeConfiguration.java
+++ b/src/main/java/com/hotels/bdp/circustrain/bigquery/RuntimeConfiguration.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/hotels/bdp/circustrain/bigquery/api/TableService.java
+++ b/src/main/java/com/hotels/bdp/circustrain/bigquery/api/TableService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/hotels/bdp/circustrain/bigquery/client/BigQueryMetastoreClient.java
+++ b/src/main/java/com/hotels/bdp/circustrain/bigquery/client/BigQueryMetastoreClient.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -124,11 +124,6 @@ class BigQueryMetastoreClient implements CloseableMetaStoreClient {
     this.tableServiceFactory = tableServiceFactory;
     this.cache = cache;
     this.schemaExtractor = schemaExtractor;
-  }
-
-  @Override
-  public boolean isOpen() {
-    return true;
   }
 
   @Override

--- a/src/main/java/com/hotels/bdp/circustrain/bigquery/client/BigQueryMetastoreClientFactory.java
+++ b/src/main/java/com/hotels/bdp/circustrain/bigquery/client/BigQueryMetastoreClientFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/hotels/bdp/circustrain/bigquery/client/HiveTableCache.java
+++ b/src/main/java/com/hotels/bdp/circustrain/bigquery/client/HiveTableCache.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/hotels/bdp/circustrain/bigquery/conf/PartitioningConfiguration.java
+++ b/src/main/java/com/hotels/bdp/circustrain/bigquery/conf/PartitioningConfiguration.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/hotels/bdp/circustrain/bigquery/context/CircusTrainBigQueryCommonBeans.java
+++ b/src/main/java/com/hotels/bdp/circustrain/bigquery/context/CircusTrainBigQueryCommonBeans.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/hotels/bdp/circustrain/bigquery/context/CircusTrainBigQueryConfiguration.java
+++ b/src/main/java/com/hotels/bdp/circustrain/bigquery/context/CircusTrainBigQueryConfiguration.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/hotels/bdp/circustrain/bigquery/conversion/BigQueryToHivePartitionConverter.java
+++ b/src/main/java/com/hotels/bdp/circustrain/bigquery/conversion/BigQueryToHivePartitionConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2019 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/hotels/bdp/circustrain/bigquery/conversion/BigQueryToHiveTableConverter.java
+++ b/src/main/java/com/hotels/bdp/circustrain/bigquery/conversion/BigQueryToHiveTableConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/hotels/bdp/circustrain/bigquery/copier/BigQueryCopier.java
+++ b/src/main/java/com/hotels/bdp/circustrain/bigquery/copier/BigQueryCopier.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/hotels/bdp/circustrain/bigquery/copier/BigQueryCopierFactory.java
+++ b/src/main/java/com/hotels/bdp/circustrain/bigquery/copier/BigQueryCopierFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/hotels/bdp/circustrain/bigquery/extraction/ExtractionContainerFactory.java
+++ b/src/main/java/com/hotels/bdp/circustrain/bigquery/extraction/ExtractionContainerFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/hotels/bdp/circustrain/bigquery/extraction/container/DeleteTableAction.java
+++ b/src/main/java/com/hotels/bdp/circustrain/bigquery/extraction/container/DeleteTableAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/hotels/bdp/circustrain/bigquery/extraction/container/ExtractionContainer.java
+++ b/src/main/java/com/hotels/bdp/circustrain/bigquery/extraction/container/ExtractionContainer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/hotels/bdp/circustrain/bigquery/extraction/container/ExtractionUri.java
+++ b/src/main/java/com/hotels/bdp/circustrain/bigquery/extraction/container/ExtractionUri.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/hotels/bdp/circustrain/bigquery/extraction/container/PostExtractionAction.java
+++ b/src/main/java/com/hotels/bdp/circustrain/bigquery/extraction/container/PostExtractionAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/hotels/bdp/circustrain/bigquery/extraction/container/UpdatePartitionSchemaAction.java
+++ b/src/main/java/com/hotels/bdp/circustrain/bigquery/extraction/container/UpdatePartitionSchemaAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/hotels/bdp/circustrain/bigquery/extraction/container/UpdateTableSchemaAction.java
+++ b/src/main/java/com/hotels/bdp/circustrain/bigquery/extraction/container/UpdateTableSchemaAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/hotels/bdp/circustrain/bigquery/extraction/service/DataCleaner.java
+++ b/src/main/java/com/hotels/bdp/circustrain/bigquery/extraction/service/DataCleaner.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/hotels/bdp/circustrain/bigquery/extraction/service/DataExtractor.java
+++ b/src/main/java/com/hotels/bdp/circustrain/bigquery/extraction/service/DataExtractor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/hotels/bdp/circustrain/bigquery/extraction/service/ExtractionService.java
+++ b/src/main/java/com/hotels/bdp/circustrain/bigquery/extraction/service/ExtractionService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/hotels/bdp/circustrain/bigquery/listener/BigQueryReplicationListener.java
+++ b/src/main/java/com/hotels/bdp/circustrain/bigquery/listener/BigQueryReplicationListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/hotels/bdp/circustrain/bigquery/partition/BigQueryPartitionGenerator.java
+++ b/src/main/java/com/hotels/bdp/circustrain/bigquery/partition/BigQueryPartitionGenerator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/hotels/bdp/circustrain/bigquery/partition/BigQueryTableFilterer.java
+++ b/src/main/java/com/hotels/bdp/circustrain/bigquery/partition/BigQueryTableFilterer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/hotels/bdp/circustrain/bigquery/partition/HivePartitionGenerator.java
+++ b/src/main/java/com/hotels/bdp/circustrain/bigquery/partition/HivePartitionGenerator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/hotels/bdp/circustrain/bigquery/partition/HivePartitionKeyAdder.java
+++ b/src/main/java/com/hotels/bdp/circustrain/bigquery/partition/HivePartitionKeyAdder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2019 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/hotels/bdp/circustrain/bigquery/partition/PartitionQueryFactory.java
+++ b/src/main/java/com/hotels/bdp/circustrain/bigquery/partition/PartitionQueryFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/hotels/bdp/circustrain/bigquery/partition/PartitionValueFormatter.java
+++ b/src/main/java/com/hotels/bdp/circustrain/bigquery/partition/PartitionValueFormatter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/hotels/bdp/circustrain/bigquery/table/service/TableServiceFactory.java
+++ b/src/main/java/com/hotels/bdp/circustrain/bigquery/table/service/TableServiceFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/hotels/bdp/circustrain/bigquery/table/service/partitioned/PartitionedTableService.java
+++ b/src/main/java/com/hotels/bdp/circustrain/bigquery/table/service/partitioned/PartitionedTableService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/hotels/bdp/circustrain/bigquery/table/service/unpartitioned/UnpartitionedTableService.java
+++ b/src/main/java/com/hotels/bdp/circustrain/bigquery/table/service/unpartitioned/UnpartitionedTableService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/hotels/bdp/circustrain/bigquery/util/AvroConstants.java
+++ b/src/main/java/com/hotels/bdp/circustrain/bigquery/util/AvroConstants.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/hotels/bdp/circustrain/bigquery/util/BigQueryMetastore.java
+++ b/src/main/java/com/hotels/bdp/circustrain/bigquery/util/BigQueryMetastore.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/hotels/bdp/circustrain/bigquery/util/RandomStringGenerationUtils.java
+++ b/src/main/java/com/hotels/bdp/circustrain/bigquery/util/RandomStringGenerationUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/hotels/bdp/circustrain/bigquery/util/SchemaExtractor.java
+++ b/src/main/java/com/hotels/bdp/circustrain/bigquery/util/SchemaExtractor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/hotels/bdp/circustrain/bigquery/util/TableNameFactory.java
+++ b/src/main/java/com/hotels/bdp/circustrain/bigquery/util/TableNameFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/hotels/bdp/circustrain/bigquery/client/BigQueryMetastoreClientFactoryTest.java
+++ b/src/test/java/com/hotels/bdp/circustrain/bigquery/client/BigQueryMetastoreClientFactoryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/hotels/bdp/circustrain/bigquery/client/BigQueryMetastoreClientTest.java
+++ b/src/test/java/com/hotels/bdp/circustrain/bigquery/client/BigQueryMetastoreClientTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/hotels/bdp/circustrain/bigquery/conf/PartitioningConfigurationTest.java
+++ b/src/test/java/com/hotels/bdp/circustrain/bigquery/conf/PartitioningConfigurationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/hotels/bdp/circustrain/bigquery/context/CircusTrainBigQueryCommonBeansTest.java
+++ b/src/test/java/com/hotels/bdp/circustrain/bigquery/context/CircusTrainBigQueryCommonBeansTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/hotels/bdp/circustrain/bigquery/context/CircusTrainBigQueryConfigurationTest.java
+++ b/src/test/java/com/hotels/bdp/circustrain/bigquery/context/CircusTrainBigQueryConfigurationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/hotels/bdp/circustrain/bigquery/conversion/BigQueryToHivePartitionConverterTest.java
+++ b/src/test/java/com/hotels/bdp/circustrain/bigquery/conversion/BigQueryToHivePartitionConverterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/hotels/bdp/circustrain/bigquery/conversion/BigQueryToHiveTableConverterTest.java
+++ b/src/test/java/com/hotels/bdp/circustrain/bigquery/conversion/BigQueryToHiveTableConverterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/hotels/bdp/circustrain/bigquery/copier/BigQueryCopierFactoryTest.java
+++ b/src/test/java/com/hotels/bdp/circustrain/bigquery/copier/BigQueryCopierFactoryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/hotels/bdp/circustrain/bigquery/copier/BigQueryCopierTest.java
+++ b/src/test/java/com/hotels/bdp/circustrain/bigquery/copier/BigQueryCopierTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/hotels/bdp/circustrain/bigquery/extraction/container/DeleteTableActionTest.java
+++ b/src/test/java/com/hotels/bdp/circustrain/bigquery/extraction/container/DeleteTableActionTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/hotels/bdp/circustrain/bigquery/extraction/container/ExtractionUriTest.java
+++ b/src/test/java/com/hotels/bdp/circustrain/bigquery/extraction/container/ExtractionUriTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/hotels/bdp/circustrain/bigquery/extraction/container/UpdatePartitionSchemaActionTest.java
+++ b/src/test/java/com/hotels/bdp/circustrain/bigquery/extraction/container/UpdatePartitionSchemaActionTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/hotels/bdp/circustrain/bigquery/extraction/container/UpdateTableSchemaActionTest.java
+++ b/src/test/java/com/hotels/bdp/circustrain/bigquery/extraction/container/UpdateTableSchemaActionTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/hotels/bdp/circustrain/bigquery/extraction/service/DataCleanerTest.java
+++ b/src/test/java/com/hotels/bdp/circustrain/bigquery/extraction/service/DataCleanerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/hotels/bdp/circustrain/bigquery/extraction/service/DataExtractorTest.java
+++ b/src/test/java/com/hotels/bdp/circustrain/bigquery/extraction/service/DataExtractorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/hotels/bdp/circustrain/bigquery/extraction/service/ExtractionServiceTest.java
+++ b/src/test/java/com/hotels/bdp/circustrain/bigquery/extraction/service/ExtractionServiceTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/hotels/bdp/circustrain/bigquery/listener/BigQueryReplicationListenerTest.java
+++ b/src/test/java/com/hotels/bdp/circustrain/bigquery/listener/BigQueryReplicationListenerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/hotels/bdp/circustrain/bigquery/partition/BigQueryPartitionGeneratorTest.java
+++ b/src/test/java/com/hotels/bdp/circustrain/bigquery/partition/BigQueryPartitionGeneratorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/hotels/bdp/circustrain/bigquery/partition/BigQueryTableFiltererTest.java
+++ b/src/test/java/com/hotels/bdp/circustrain/bigquery/partition/BigQueryTableFiltererTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/hotels/bdp/circustrain/bigquery/partition/HivePartitionGeneratorTest.java
+++ b/src/test/java/com/hotels/bdp/circustrain/bigquery/partition/HivePartitionGeneratorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/hotels/bdp/circustrain/bigquery/partition/HivePartitionKeyAdderTest.java
+++ b/src/test/java/com/hotels/bdp/circustrain/bigquery/partition/HivePartitionKeyAdderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/hotels/bdp/circustrain/bigquery/partition/PartitionQueryFactoryTest.java
+++ b/src/test/java/com/hotels/bdp/circustrain/bigquery/partition/PartitionQueryFactoryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/hotels/bdp/circustrain/bigquery/partition/PartitionValueFormatterTest.java
+++ b/src/test/java/com/hotels/bdp/circustrain/bigquery/partition/PartitionValueFormatterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/hotels/bdp/circustrain/bigquery/table/service/TableServiceFactoryTest.java
+++ b/src/test/java/com/hotels/bdp/circustrain/bigquery/table/service/TableServiceFactoryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/hotels/bdp/circustrain/bigquery/table/service/partitioned/PartitionedTableServiceTest.java
+++ b/src/test/java/com/hotels/bdp/circustrain/bigquery/table/service/partitioned/PartitionedTableServiceTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/hotels/bdp/circustrain/bigquery/table/service/unpartitioned/UnpartitionedTableServiceTest.java
+++ b/src/test/java/com/hotels/bdp/circustrain/bigquery/table/service/unpartitioned/UnpartitionedTableServiceTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/hotels/bdp/circustrain/bigquery/util/BigQueryMetastoreTest.java
+++ b/src/test/java/com/hotels/bdp/circustrain/bigquery/util/BigQueryMetastoreTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/hotels/bdp/circustrain/bigquery/util/SchemaExtractorTest.java
+++ b/src/test/java/com/hotels/bdp/circustrain/bigquery/util/SchemaExtractorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/hotels/bdp/circustrain/bigquery/util/SchemaUtils.java
+++ b/src/test/java/com/hotels/bdp/circustrain/bigquery/util/SchemaUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/hotels/bdp/circustrain/bigquery/util/StubReadChannel.java
+++ b/src/test/java/com/hotels/bdp/circustrain/bigquery/util/StubReadChannel.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/hotels/bdp/circustrain/bigquery/util/TableNameFactoryTest.java
+++ b/src/test/java/com/hotels/bdp/circustrain/bigquery/util/TableNameFactoryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/log4j.xml
+++ b/src/test/resources/log4j.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
-  Copyright (C) 2018 Expedia Inc.
+  Copyright (C) 2018-2019 Expedia, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.


### PR DESCRIPTION
* Upgraded `hotels-oss-parent` to 4.0.1 (was 2.3.3).
* Upgraded `circus-train-version` to 14.0.1 (was 13.0.0).